### PR TITLE
ensure logoot to be idempotent

### DIFF
--- a/lib/logoot.js
+++ b/lib/logoot.js
@@ -35,6 +35,10 @@ require('util').inherits(Logoot, EventEmitter);
  */
 Logoot.prototype.ins = function (id, atom, agent, insertAfter) {
   var ids = this.ids;
+  if (ids.indexOf(id) >= 0) {
+    return;
+  } // edit RvV: atom already inserted
+
   if (arguments.length === 3) {
     insertAfter = indexOfGreatestLessThan(ids, id, compare);
   }
@@ -58,6 +62,10 @@ Logoot.prototype.ins = function (id, atom, agent, insertAfter) {
  */
 Logoot.prototype.del = function (id, agent, indexOfId) {
   var ids = this.ids;
+  if (ids.indexOf(id) === -1) {
+    return;
+  } // edit RvV: atom already deleted
+
   indexOfId || (indexOfId = indexOf(ids, id, compare));
   ids.splice(indexOfId, 1);
   var atom = this.atoms[hashId(id)];


### PR DESCRIPTION
If an (external) insert operation on an existing atom, or a delete on a
non-existing atom is received, ignore it.
